### PR TITLE
BUG (SQL Lab): Fixes rendering of strings with angle brackets

### DIFF
--- a/superset-frontend/src/components/FilterableTable/utils.test.tsx
+++ b/superset-frontend/src/components/FilterableTable/utils.test.tsx
@@ -76,3 +76,23 @@ test('should transform cell data by getCellContent for the regular text', () => 
   );
   expect(container).toHaveTextContent('regular_text:a');
 });
+
+test('should render strings with angle brackets as text', () => {
+  const { container } = render(
+    <>
+      {renderResultCell({
+        cellData: '<div>test</div>',
+        columnKey: 'html_column',
+      })}
+    </>,
+  );
+  // Should display the angle brackets as text, not render as HTML
+  expect(container).toHaveTextContent('<div>test</div>');
+  // Should NOT have any div elements rendered (only the wrapper span)
+  // The container should only have one span element (our wrapper)
+  const spans = container.querySelectorAll('span');
+  expect(spans.length).toBe(1);
+  // Should NOT have any div elements from the cell content
+  const divs = container.querySelectorAll('div');
+  expect(divs.length).toBe(0);
+});

--- a/superset-frontend/src/components/FilterableTable/utils.tsx
+++ b/superset-frontend/src/components/FilterableTable/utils.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { JsonModal, safeJsonObjectParse } from 'src/components/JsonModal';
-import { t, safeHtmlSpan } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
 import { NULL_STRING, CellDataType } from './useCellContentParser';
 
 type CellParams = {
@@ -52,7 +52,10 @@ export const renderResultCell = ({
     );
   }
   if (allowHTML && typeof cellData === 'string') {
-    return safeHtmlSpan(cellNode);
+    // Render the string as plain text content. React automatically escapes HTML entities
+    // when rendering text, so strings like '<div>test</div>' will be safely displayed
+    // as text without being interpreted as HTML markup
+    return <span>{cellNode}</span>;
   }
   return cellNode;
 };


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
[Issue](https://github.com/JuliettaRozin/superset/issues/4#issue-3467431814) stated that in SQL Lab, query results with strings that contained HTML-like strings, such as angle brackets (< >), are not rendered properly, displaying as if there is no data or missing data.
This solution edits the function that renders the cells of the SQL Lab query results. It replaces the usage of a safeHtmlSpan function, which detects HTML-like strings and tries to render them as HTML, with a <span> that takes the text inputted in the query and renders it as a string. It is assumed that HTML rendering is not expected by the user when using SQL Lab, which is what this solution addresses.

### CODE REVIEW & BEFORE/AFTER DEMO
[Before/After Demo & Code Review](https://youtu.be/YXZrniFiFTk)

### TESTING 
<!--- Required! What steps can be taken to manually verify the changes? -->
A manual test was performed in SQL Lab, where the query `SELECT '<div>test</div>' as html_string` as the input returned the full string: `<div>test</div>`. Additionally, the ampersand (&) and double quotation (") were tested within the query and successfully returned as a string.
A unit test was also added that tests that the text in the cell is the string representation of the query, with all the information. Additionally, it verifies that there is a single `<span>` element, which is the wrapper in the solution, and that there is no `<div>` element, which ensures that the HTML inside the string is not being interpreted as HTML. 

### BEFORE/AFTER SCREENSHOTS
<!--- Skip this if not applicable -->
**BEFORE**
<img width="438" height="143" alt="image" src="https://github.com/user-attachments/assets/35391718-ef4c-4ffb-83eb-8e43a5f17bd4" />

**AFTER**
<img width="450" height="155" alt="image" src="https://github.com/user-attachments/assets/db10d279-17f4-491c-9462-14ce312af131" />

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
- [x] Fixes #4 