### PR TITLE
FEAT (Chart): Browser tab title changes with chart name

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -321,7 +321,10 @@
     "eslint-rules/eslint-plugin-icons": {
       "version": "1.0.0",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "eslint": ">=0.8.0"
+      }
     },
     "eslint-rules/eslint-plugin-theme-colors": {
       "version": "1.0.0",

--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -299,3 +299,58 @@ test('does omit hiddenFormData when query_mode is not enabled', async () => {
     expect(formData[key]).toBeUndefined();
   });
 });
+
+test('updates document title when sliceName is provided', async () => {
+  const originalTitle = document.title;
+  const customState = {
+    ...reduxState,
+    explore: {
+      ...reduxState.explore,
+      sliceName: 'Test Chart Name',
+    },
+  };
+
+  await waitFor(() => renderWithRouter({ initialState: customState }));
+  
+  expect(document.title).toBe('Test Chart Name');
+  
+  // Cleanup
+  document.title = originalTitle;
+});
+
+test('sets document title to Superset when sliceName is null', async () => {
+  const originalTitle = document.title;
+  const customState = {
+    ...reduxState,
+    explore: {
+      ...reduxState.explore,
+      sliceName: null,
+    },
+  };
+
+  await waitFor(() => renderWithRouter({ initialState: customState }));
+  
+  expect(document.title).toBe('Superset');
+  
+  // Cleanup
+  document.title = originalTitle;
+});
+
+test('resets document title when component unmounts', async () => {
+  const originalTitle = document.title;
+  const customState = {
+    ...reduxState,
+    explore: {
+      ...reduxState.explore,
+      sliceName: 'Test Chart Name',
+    },
+  };
+
+  const { unmount } = renderWithRouter({ initialState: customState });
+  
+  expect(document.title).toBe('Test Chart Name');
+  
+  unmount();
+  
+  expect(document.title).toBe(originalTitle);
+});

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -238,6 +238,8 @@ const defaultSidebarsWidth = {
   datasource_width: 300,
 };
 
+const originalDocumentTitle = document.title;
+
 function getSidebarWidths(key) {
   return getItem(key, defaultSidebarsWidth[key]);
 }
@@ -413,6 +415,18 @@ function ExploreViewContainer(props) {
       props.actions.triggerQuery(true, props.chart.id);
     }
   }, []);
+
+  // Manage browser tab title based on chart name
+  useEffect(() => {
+    if (props.sliceName) {
+      document.title = props.sliceName;
+    } else {
+      document.title = 'Superset';
+    }
+    return () => {
+      document.title = originalDocumentTitle;
+    };
+  }, [props.sliceName]);
 
   const reRenderChart = useCallback(
     controlsChanged => {

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -238,8 +238,6 @@ const defaultSidebarsWidth = {
   datasource_width: 300,
 };
 
-const originalDocumentTitle = document.title;
-
 function getSidebarWidths(key) {
   return getItem(key, defaultSidebarsWidth[key]);
 }
@@ -420,11 +418,9 @@ function ExploreViewContainer(props) {
   useEffect(() => {
     if (props.sliceName) {
       document.title = props.sliceName;
-    } else {
-      document.title = 'Superset';
-    }
+    } 
     return () => {
-      document.title = originalDocumentTitle;
+      document.title = 'Superset';  // Reset to default superset title
     };
   }, [props.sliceName]);
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
[Issue](https://github.com/JuliettaRozin/superset/issues/10#issue-3529253931) stated that the browser tab title does not change with the open chart, making it hard to navigate between multiple tabs. 
This solution works with the ExploreViewContainer and utilizes a useEffect hook to determine when a chart name changes, and accordingly updates the name of the browser tab. When a chart is not opened, the browser tab defaults to the "Superset" title.

### CODE REVIEW & BEFORE/AFTER DEMO
[Before/After Demo & Code Review](https://youtu.be/mDX6MvmVot8)

### TESTING 
<!--- Required! What steps can be taken to manually verify the changes? -->
The following manual tests were performed:
- The Superset landing page is loaded: browser tab title is "Superset"
- A chart is selected in Explore view: browser tab title changes to chart's name
- Chart is exited out of: browser tab title changes back to "Superset"
- Another chart is selected: browser tab title changes to new chart's name
- Multiple tabs are opened, each portraying a different chart: browser tabs show respective chart table names or the default Superset title

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
- [x] Fixes #10 
